### PR TITLE
Add MIT Licence

### DIFF
--- a/.github/workflows/fabric-parallel.yaml
+++ b/.github/workflows/fabric-parallel.yaml
@@ -1,4 +1,4 @@
-name: fabric-parallel
+name: Fabric
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -1,4 +1,4 @@
-name: minecraft-parallel
+name: Minecraft
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/paper-parallel.yaml
+++ b/.github/workflows/paper-parallel.yaml
@@ -1,4 +1,4 @@
-name: paper-parallel
+name: Paper
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/velocity-parallel.yaml
+++ b/.github/workflows/velocity-parallel.yaml
@@ -1,4 +1,4 @@
-name: velocity-parallel
+name: Velocity
 on:
   workflow_dispatch:
   schedule:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+The MIT License (MIT)
+=====================
+
+Copyright © 2022 Anthony Porthouse
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker Minecraft
 
 [![Minecraft](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/minecraft-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/minecraft-parallel.yaml)
-[![Fabric(https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/fabric-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/fabric-parallel.yaml)
+[![Fabric](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/fabric-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/fabric-parallel.yaml)
 [![Paper](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/paper-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/paper-parallel.yaml)
 [![Purpur](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/purpur-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/purpur-parallel.yaml)
 [![Velocity](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/velocity-parallel.yaml/badge.svg)](https://github.com/AnthonyPorthouse/docker-minecraft/actions/workflows/velocity-parallel.yaml)


### PR DESCRIPTION
Fix typo in the README add the MIT Licence and rename the github actions
to be more human readable.
