### PR TITLE
Refactor docker build and deploy into actions

### DIFF
--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -81,8 +81,8 @@ jobs:
         id: snapshot-build-info
         run: ./minecraft/build/build-snapshot.sh
       - name: Build Latest
-        if: steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
         uses: docker/build-push-action@v3
+        if: steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
         with:
           context: minecraft
           tags: |
@@ -93,8 +93,8 @@ jobs:
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
       - name: Build
-        if: steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
         uses: docker/build-push-action@v3
+        if: steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
         with:
           context: minecraft
           tags: |
@@ -103,7 +103,8 @@ jobs:
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
-      - name: Push
+      - name: Push Latest
+        uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
         with:
           context: minecraft
@@ -116,6 +117,7 @@ jobs:
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
       - name: Push
+        uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
         with:
           context: minecraft

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -56,7 +56,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
       - name: Build
         uses: docker/build-push-action@v3
         if: steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
@@ -67,7 +67,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
       - name: Push Latest
         uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
@@ -80,7 +80,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
       - name: Push
         uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
@@ -92,7 +92,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
 
   get-snapshot-versions:
     name: Get Minecraft Snapshot Releases
@@ -141,7 +141,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
       - name: Build
         uses: docker/build-push-action@v3
         if: steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
@@ -152,7 +152,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
       - name: Push Latest
         uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
@@ -165,7 +165,7 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
       - name: Push
         uses: docker/build-push-action@v3
         if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
@@ -177,4 +177,4 @@ jobs:
           build-args: |
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
-            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+            JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
+  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -70,10 +71,58 @@ jobs:
       VERSION: ${{ toJSON(matrix.version) }}
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-actions@v2
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
+      - name: Get Snapshot Build Info
+        id: snapshot-build-info
         run: ./minecraft/build/build-snapshot.sh
+      - name: Build Latest
+        if: steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+        uses: docker/build-push-action@v3
+        with:
+          context: minecraft
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest-snapshot
+            ${{ env.IMAGE_NAME }}:${{ steps.snapshot-build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+      - name: Build
+        if: steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+        uses: docker/build-push-action@v3
+        with:
+          context: minecraft
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.snapshot-build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+      - name: Push
+        if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+        with:
+          context: minecraft
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest-snapshot
+            ${{ env.IMAGE_NAME }}:${{ steps.snapshot-build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}
+      - name: Push
+        if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+        with:
+          context: minecraft
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.snapshot-build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.snapshot-build-info.outputs.java_version }}

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -36,13 +36,63 @@ jobs:
       VERSION: ${{ toJSON(matrix.version) }}
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
+      - name: Get Build Info
+        id: build-info
         run: ./minecraft/build/build-version.sh
+      - name: Build Latest
+        uses: docker/build-push-action@v3
+        if: steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+        with:
+          context: minecraft
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+      - name: Build
+        uses: docker/build-push-action@v3
+        if: steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+        with:
+          context: minecraft
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+      - name: Push Latest
+        uses: docker/build-push-action@v3
+        if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+        with:
+          context: minecraft
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
+      - name: Push
+        uses: docker/build-push-action@v3
+        if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+        with:
+          context: minecraft
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.build-info.outputs.minecraft_version }}
+          build-args: |
+            MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
+            SERVER_URL=${{ steps.build-info.outputs.server_url }}
+            JAVA_IMAGE=${{ steps.build-info.outputs.java_version }}
 
   get-snapshot-versions:
     name: Get Minecraft Snapshot Releases
@@ -71,7 +121,7 @@ jobs:
       VERSION: ${{ toJSON(matrix.version) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-actions@v2
+      - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -45,9 +45,12 @@ jobs:
       - name: Get Build Info
         id: build-info
         run: ./minecraft/build/build-version.sh
+
       - name: Build Latest
         uses: docker/build-push-action@v3
-        if: steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+        if: |
+          steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+          && steps.build-info.outputs.server_url != null
         with:
           context: minecraft
           tags: |
@@ -57,9 +60,12 @@ jobs:
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
+
       - name: Build
         uses: docker/build-push-action@v3
-        if: steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+        if: |
+          steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+          && steps.build-info.outputs.server_url != null
         with:
           context: minecraft
           tags: |
@@ -68,9 +74,13 @@ jobs:
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
+
       - name: Push Latest
         uses: docker/build-push-action@v3
-        if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+        if: |
+          github.ref == 'refs/heads/main'
+          && steps.build-info.outputs.minecraft_version == env.LATEST_VERSION
+          && steps.build-info.outputs.server_url != null
         with:
           context: minecraft
           push: true
@@ -81,9 +91,13 @@ jobs:
             MINECRAFT_VERSION=${{ steps.build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.build-info.outputs.java_version }}-alpine
+
       - name: Push
         uses: docker/build-push-action@v3
-        if: github.ref == 'refs/heads/main' && steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+        if: |
+          github.ref == 'refs/heads/main'
+          && steps.build-info.outputs.minecraft_version != env.LATEST_VERSION
+          && steps.build-info.outputs.server_url != null
         with:
           context: minecraft
           push: true
@@ -130,9 +144,12 @@ jobs:
       - name: Get Snapshot Build Info
         id: snapshot-build-info
         run: ./minecraft/build/build-snapshot.sh
+
       - name: Build Latest
         uses: docker/build-push-action@v3
-        if: steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+        if: |
+          steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+          && steps.snapshot-build-info.outputs.server_url != null
         with:
           context: minecraft
           tags: |
@@ -142,9 +159,12 @@ jobs:
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
+
       - name: Build
         uses: docker/build-push-action@v3
-        if: steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+        if: |
+          steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+          && steps.snapshot-build-info.outputs.server_url != null
         with:
           context: minecraft
           tags: |
@@ -153,9 +173,13 @@ jobs:
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
+
       - name: Push Latest
         uses: docker/build-push-action@v3
-        if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+        if: |
+          github.ref == 'refs/heads/main'
+          && steps.snapshot-build-info.outputs.minecraft_version == env.LATEST_VERSION
+          && steps.snapshot-build-info.outputs.server_url != null
         with:
           context: minecraft
           push: true
@@ -166,9 +190,13 @@ jobs:
             MINECRAFT_VERSION=${{ steps.snapshot-build-info.outputs.minecraft_version }}
             SERVER_URL=${{ steps.snapshot-build-info.outputs.server_url }}
             JAVA_IMAGE=eclipse-temurin:${{ steps.snapshot-build-info.outputs.java_version }}-alpine
+
       - name: Push
         uses: docker/build-push-action@v3
-        if: github.ref == 'refs/heads/main' && steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+        if: |
+          github.ref == 'refs/heads/main'
+          && steps.snapshot-build-info.outputs.minecraft_version != env.LATEST_VERSION
+          && steps.snapshot-build-info.outputs.server_url != null
         with:
           context: minecraft
           push: true

--- a/.github/workflows/minecraft-parallel.yaml
+++ b/.github/workflows/minecraft-parallel.yaml
@@ -4,7 +4,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
   pull_request:
-
+  push:
+    branches:
+      - main
 env:
   REGISTRY: ghcr.io
 

--- a/minecraft/build/build-snapshot.sh
+++ b/minecraft/build/build-snapshot.sh
@@ -9,6 +9,7 @@ version="${VERSION:-}"
 
 IMAGE_NAME=${IMAGE_NAME:-port3m5/minecraft}
 IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+echo "IMAGE_NAME=$IMAGE_NAME" >> "$GITHUB_ENV"
 
 minecraft_version=$(jq -r '.id' <<< "$version")
 

--- a/minecraft/build/build-snapshot.sh
+++ b/minecraft/build/build-snapshot.sh
@@ -5,7 +5,6 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
-latest="${LATEST_VERSION:-}"
 version="${VERSION:-}"
 
 IMAGE_NAME=${IMAGE_NAME:-port3m5/minecraft}
@@ -31,23 +30,3 @@ fi
 echo "::set-output name=minecraft_version::$minecraft_version"
 echo "::set-output name=server_url::$server_url"
 echo "::set-output name=java_version::$java_version"
-
-docker build \
-    --build-arg MINECRAFT_VERSION="$minecraft_version" \
-    --build-arg SERVER_URL="$server_url" \
-    --build-arg JAVA_IMAGE="eclipse-temurin:$java_version-alpine" \
-    -t "$IMAGE_NAME:${minecraft_version}" \
-    minecraft
-
-docker push "$IMAGE_NAME:${minecraft_version}"
-
-if [ "$minecraft_version" == "$latest" ]; then
-    docker build \
-        --build-arg MINECRAFT_VERSION="$minecraft_version" \
-        --build-arg SERVER_URL="$server_url" \
-        --build-arg JAVA_IMAGE="eclipse-temurin:$java_version-alpine" \
-        -t "$IMAGE_NAME:latest-snapshot" \
-        minecraft
-
-    docker push "$IMAGE_NAME:latest-snapshot"
-fi

--- a/minecraft/build/build-snapshot.sh
+++ b/minecraft/build/build-snapshot.sh
@@ -28,7 +28,9 @@ if [ "$server_url" == "null" ]; then
     exit 0
 fi
 
-set -x
+echo "::set-output name=minecraft_version::$minecraft_version"
+echo "::set-output name=server_url::$server_url"
+echo "::set-output name=java_version::$java_version"
 
 docker build \
     --build-arg MINECRAFT_VERSION="$minecraft_version" \

--- a/minecraft/build/build-version.sh
+++ b/minecraft/build/build-version.sh
@@ -5,7 +5,6 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
-latest="${LATEST_VERSION:-}"
 version="${VERSION:-}"
 
 IMAGE_NAME=${IMAGE_NAME:-port3m5/minecraft}
@@ -28,24 +27,6 @@ if [ "$server_url" == "null" ]; then
     exit 0
 fi
 
-set -x
-
-docker build \
-    --build-arg MINECRAFT_VERSION="$minecraft_version" \
-    --build-arg SERVER_URL="$server_url" \
-    --build-arg JAVA_IMAGE="eclipse-temurin:$java_version-alpine" \
-    -t "$IMAGE_NAME:${minecraft_version}" \
-    minecraft
-
-docker push "$IMAGE_NAME:${minecraft_version}"
-
-if [ "$minecraft_version" == "$latest" ]; then
-    docker build \
-        --build-arg MINECRAFT_VERSION="$minecraft_version" \
-        --build-arg SERVER_URL="$server_url" \
-        --build-arg JAVA_IMAGE="eclipse-temurin:$java_version-alpine" \
-        -t "$IMAGE_NAME" \
-        minecraft
-
-    docker push "$IMAGE_NAME"
-fi
+echo "::set-output name=minecraft_version::$minecraft_version"
+echo "::set-output name=server_url::$server_url"
+echo "::set-output name=java_version::$java_version"

--- a/minecraft/build/build-version.sh
+++ b/minecraft/build/build-version.sh
@@ -9,6 +9,7 @@ version="${VERSION:-}"
 
 IMAGE_NAME=${IMAGE_NAME:-port3m5/minecraft}
 IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+echo "IMAGE_NAME=$IMAGE_NAME" >> "$GITHUB_ENV"
 
 minecraft_version=$(jq -r '.id' <<< "$version")
 


### PR DESCRIPTION
This work allows us to run builds without deploying in PRs, meaning we
can get a much better idea if changes will break our pipelines without
actually having to merge them into main.